### PR TITLE
Feature Suggestion: Additional Column in the Directory

### DIFF
--- a/components/TurtleRP_Directory.xml
+++ b/components/TurtleRP_Directory.xml
@@ -219,6 +219,31 @@
             </Anchor>
           </Anchors>
         </Texture>
+        <!-- Layers Added to expand size of frame, placed in background to render behind the rest as filler -->
+        <Texture name="$parent_BottomRight2" file="Interface\FriendsFrame\WhoFrame-BotRight">
+          <Size>
+            <AbsDimension x="175" y="256"/>
+          </Size>
+          <Anchors>
+            <Anchor point="BOTTOMRIGHT">
+              <Offset>
+                <AbsDimension x="-90" y="0"/>
+              </Offset>
+            </Anchor>
+          </Anchors>
+        </Texture>
+        <Texture name="$parent_TopRight2" file="Interface\ClassTrainerFrame\UI-ClassTrainer-TopRight">
+        <Size>
+          <AbsDimension x="175" y="256"/>
+        </Size>
+        <Anchors>
+          <Anchor point="TOPRIGHT">
+            <Offset>
+              <AbsDimension x="-90" y="0"/>
+            </Offset>
+          </Anchor>
+        </Anchors>
+      </Texture>
       </Layer>
       <Layer level="ARTWORK">
         <Texture name="$parent_TopLeft" file="Interface\ClassTrainerFrame\UI-ClassTrainer-TopLeft">
@@ -237,12 +262,12 @@
         <Texture name="$parent_TopRight" file="Interface\ClassTrainerFrame\UI-ClassTrainer-TopRight">
         <!-- <Texture name="$parent_TopRight" file="Interface\PaperDollInfoFrame\UI-Character-General-TopRight"> -->
           <Size>
-            <AbsDimension x="256" y="256"/>
+            <AbsDimension x="128" y="256"/>
           </Size>
           <Anchors>
             <Anchor point="TOPRIGHT">
               <Offset>
-                <AbsDimension x="0" y="0"/>
+                <AbsDimension x="-50" y="0"/>
               </Offset>
             </Anchor>
           </Anchors>
@@ -261,12 +286,12 @@
         </Texture>
         <Texture name="$parent_BottomRight" file="Interface\FriendsFrame\WhoFrame-BotRight">
           <Size>
-            <AbsDimension x="256" y="256"/>
+            <AbsDimension x="128" y="256"/>
           </Size>
           <Anchors>
             <Anchor point="BOTTOMRIGHT">
               <Offset>
-                <AbsDimension x="0" y="0"/>
+                <AbsDimension x="-50" y="0"/>
               </Offset>
             </Anchor>
           </Anchors>
@@ -277,7 +302,7 @@
           <Anchors>
             <Anchor point="TOP">
               <Offset>
-                <AbsDimension x="0" y="-18"/>
+                <AbsDimension x="-15" y="-18"/>
               </Offset>
             </Anchor>
           </Anchors>
@@ -335,35 +360,6 @@
                   </Anchors>
                 </FontString>
               </Layer>
-              <!-- <Layer level="BACKGROUND">
-                <Texture name="$parent_FrameRight" file="Interface\ClassTrainerFrame\UI-ClassTrainer-FilterBorder">
-                  <Size>
-                    <AbsDimension x="12" y="28"/>
-                  </Size>
-                  <Anchors>
-                    <Anchor point="TOPRIGHT"/>
-                  </Anchors>
-                  <TexCoords left="0.90625" right="1.0" top="0" bottom="1.0"/>
-                </Texture>
-                <Texture name="$parent_FrameMiddle" file="Interface\ClassTrainerFrame\UI-ClassTrainer-FilterBorder">
-                  <Size>
-                    <AbsDimension x="186" y="28"/>
-                  </Size>
-                  <Anchors>
-                    <Anchor point="RIGHT" relativeTo="$parent_FrameRight" relativePoint="LEFT"/>
-                  </Anchors>
-                  <TexCoords left="0.09375" right="0.90625" top="0" bottom="1.0"/>
-                </Texture>
-                <Texture name="$parent_FrameLeft" file="Interface\ClassTrainerFrame\UI-ClassTrainer-FilterBorder">
-                  <Size>
-                    <AbsDimension x="12" y="28"/>
-                  </Size>
-                  <Anchors>
-                    <Anchor point="RIGHT" relativeTo="$parent_FrameMiddle" relativePoint="LEFT"/>
-                  </Anchors>
-                  <TexCoords left="0" right="0.09375" top="0" bottom="1.0"/>
-                </Texture>
-              </Layer> -->
             </Layers>
             <Frames>
               <!-- <CheckButton name="$parent_LFGButton" virtual="true">
@@ -855,7 +851,7 @@
             <Anchors>
               <Anchor point="TOPRIGHT" relativeTo="$parent" relativePoint="TOPRIGHT">
                 <Offset>
-                  <AbsDimension x="-95" y="-96"/>
+                  <AbsDimension x="-110" y="-96"/>
                 </Offset>
               </Anchor>
             </Anchors>

--- a/components/TurtleRP_Directory.xml
+++ b/components/TurtleRP_Directory.xml
@@ -2,7 +2,7 @@
 
   <Button name="TurtleRP_DirectoryButtonTemplate" virtual="true">
     <Size>
-      <AbsDimension x="298" y="16"/>
+      <AbsDimension x="440" y="16"/>
     </Size>
     <Layers>
       <Layer level="BORDER">
@@ -106,6 +106,43 @@
          <Color r="0.2" g="0.2" b="0.2" a="0.7"  />
         </Backdrop>
       </Frame>
+      <!-- NSFW Status icons -->
+      <Frame name="$parent_NSFWStatusTrue" hidden="true">
+        <Size>
+          <AbsDimension x="5" y="5" />
+        </Size>
+        <Anchors>
+          <Anchor point="LEFT" relativeTo="$parentVariable" relativePoint="RIGHT">
+            <Offset>
+              <AbsDimension x="80" y="0"/>
+            </Offset>
+          </Anchor>
+        </Anchors>
+        <Backdrop alphaMode="ADD" bgFile="Interface\Buttons\WHITE8x8" tile="false">
+         <TileSize>
+           <AbsValue val="10"/>
+         </TileSize>
+         <Color r="0" g="1" b="0" a="0.7" />
+        </Backdrop>
+      </Frame>
+      <Frame name="$parent_NSFWStatusFalse" hidden="true">
+        <Size>
+          <AbsDimension x="5" y="5" />
+        </Size>
+        <Anchors>
+          <Anchor point="LEFT" relativeTo="$parentVariable" relativePoint="RIGHT">
+            <Offset>
+              <AbsDimension x="80" y="0"/>
+            </Offset>
+          </Anchor>
+        </Anchors>
+        <Backdrop alphaMode="ADD" bgFile="Interface\Buttons\WHITE8x8" tile="false">
+         <TileSize>
+           <AbsValue val="10"/>
+         </TileSize>
+         <Color r="0.2" g="0.2" b="0.2" a="0.7"  />
+        </Backdrop>
+      </Frame>
     </Frames>
     <Scripts>
       <OnClick>
@@ -142,7 +179,7 @@
     </Scripts>
     <HighlightTexture file="Interface\QuestFrame\UI-QuestTitleHighlight" alphaMode="ADD">
       <Size>
-        <AbsDimension x="298" y="16"/>
+        <AbsDimension x="390" y="16"/>
       </Size>
       <Anchors>
         <Anchor point="TOP">
@@ -156,7 +193,7 @@
 
   <Frame name="TurtleRP_DirectoryFrame" toplevel="true" parent="UIParent" movable="true" enableMouse="true" hidden="true">
     <Size>
-      <AbsDimension x="384" y="512"/>
+      <AbsDimension x="512" y="512"/>
     </Size>
     <Anchors>
       <Anchor point="TOPLEFT">
@@ -200,7 +237,7 @@
         <Texture name="$parent_TopRight" file="Interface\ClassTrainerFrame\UI-ClassTrainer-TopRight">
         <!-- <Texture name="$parent_TopRight" file="Interface\PaperDollInfoFrame\UI-Character-General-TopRight"> -->
           <Size>
-            <AbsDimension x="128" y="256"/>
+            <AbsDimension x="256" y="256"/>
           </Size>
           <Anchors>
             <Anchor point="TOPRIGHT">
@@ -224,7 +261,7 @@
         </Texture>
         <Texture name="$parent_BottomRight" file="Interface\FriendsFrame\WhoFrame-BotRight">
           <Size>
-            <AbsDimension x="128" y="256"/>
+            <AbsDimension x="256" y="256"/>
           </Size>
           <Anchors>
             <Anchor point="BOTTOMRIGHT">
@@ -252,7 +289,7 @@
         <Anchors>
           <Anchor point="TOPRIGHT">
             <Offset>
-              <AbsDimension x="-30" y="-8"/>
+              <AbsDimension x="-80" y="-8"/>
             </Offset>
           </Anchor>
         </Anchors>
@@ -292,7 +329,7 @@
                   <Anchors>
                     <Anchor point="RIGHT" relativePoint="RIGHT">
                       <Offset>
-                        <AbsDimension x="-10" y="1"/>
+                        <AbsDimension x="-50" y="1"/>
                       </Offset>
                     </Anchor>
                   </Anchors>
@@ -497,6 +534,30 @@
                 TurtleRP.updateDirectorySearch()
                 TurtleRP_DirectoryFrame_Directory_ScrollFrameScrollBar:SetValue(0)
                 TurtleRP.Directory_ScrollBar_Update()
+              </OnClick>
+            </Scripts>
+          </Button>
+          <Button name="NSFW_Column" inherits="WhoFrameColumnHeaderTemplate" text="NSFW Flag">
+            <Anchors>
+              <Anchor point="LEFT" relativeTo="$parent_ColumnHeader3" relativePoint="RIGHT">
+                <Offset>
+                  <AbsDimension x="-2" y="0"/>
+                </Offset>
+              </Anchor>
+            </Anchors>
+            <Scripts>
+              <OnLoad>
+                local width = 85
+                this:SetWidth(width);
+                getglobal(this:GetName().."Middle"):SetWidth(width - 9);
+              </OnLoad>
+              <OnClick>
+                if TurtleRP.sortByKey == "nsfw" then
+                  TurtleRP.sortByOrder = TurtleRP.sortByOrder == 0 and 1 or 0
+                end
+                TurtleRP.sortByKey = "nsfw"
+                TurtleRP_DirectoryFrame_Directory_ScrollFrameScrollBar:SetValue(0)
+                TurtleRP.renderDirectory(0)
               </OnClick>
             </Scripts>
           </Button>
@@ -793,7 +854,7 @@
             <Anchors>
               <Anchor point="TOPRIGHT" relativeTo="$parent" relativePoint="TOPRIGHT">
                 <Offset>
-                  <AbsDimension x="-67" y="-96"/>
+                  <AbsDimension x="-95" y="-96"/>
                 </Offset>
               </Anchor>
             </Anchors>

--- a/components/TurtleRP_Directory.xml
+++ b/components/TurtleRP_Directory.xml
@@ -556,8 +556,9 @@
                   TurtleRP.sortByOrder = TurtleRP.sortByOrder == 0 and 1 or 0
                 end
                 TurtleRP.sortByKey = "nsfw"
+                TurtleRP.updateDirectorySearch()
                 TurtleRP_DirectoryFrame_Directory_ScrollFrameScrollBar:SetValue(0)
-                TurtleRP.renderDirectory(0)
+                TurtleRP.Directory_ScrollBar_Update()
               </OnClick>
             </Scripts>
           </Button>

--- a/scripts/TurtleRPDirectory.lua
+++ b/scripts/TurtleRPDirectory.lua
@@ -181,50 +181,11 @@ end
 
 function TurtleRP.renderDirectory(directoryOffset)
   local searchResults = TurtleRP.DirectorySearchResults
-  local remadeArray = {}
-  local currentArrayNumber = 1
   -- If NSFW is enabled, surface NSFW Status Column
   if TurtleRPSettings["show_nsfw"] == "1" then
     getglobal('NSFW_Column'):Show()
   else
     getglobal('NSFW_Column'):Hide()
-  end
-  for i, v in TurtleRPCharacters do
-    if TurtleRPCharacters[i] then
-      if not TurtleRPCharacters[i]['nsfw'] or TurtleRPCharacters[i]['nsfw'] == '' or TurtleRPCharacters[i]['nsfw'] == '0' or (TurtleRPCharacters[i]['nsfw'] == "1" and TurtleRPSettings["show_nsfw"] == "1") then
-         if TurtleRPCharacters[i]['full_name'] == nil then
-         TurtleRPCharacters[i]['full_name'] = ""
-         end
-         local resultShown = true
-         if TurtleRP.searchTerm ~= "" then
-         if string.find(string.lower(i), string.lower(TurtleRP.searchTerm)) == nil and string.find(string.lower(v['full_name']), string.lower(TurtleRP.searchTerm)) == nil then
-            resultShown = false
-         end
-         end
-         if resultShown then
-         remadeArray[currentArrayNumber] = v
-         remadeArray[currentArrayNumber]['player_name'] = i
-         remadeArray[currentArrayNumber]['status'] = "Offline"
-         remadeArray[currentArrayNumber]['zone'] = v['zone'] and v['zone'] or ""
-         if TurtleRPQueryablePlayers[i] then
-            if type(TurtleRPQueryablePlayers[i]) == "number" then
-               if TurtleRPQueryablePlayers[i] > (time() - 65) then
-               remadeArray[currentArrayNumber]['status'] = "Online"
-               end
-            end
-         end
-         currentArrayNumber = currentArrayNumber + 1
-         end
-      end
-    end
-  end
-
-  if TurtleRP.sortByKey ~= nil then
-    if TurtleRP.sortByOrder == 1 then
-      table.sort(remadeArray, function(a, b) return sort_users_by_key(a, b, TurtleRP.sortByKey, TurtleRP.sortByOrder) end)
-    else
-      table.sort(remadeArray, function(a, b) return sort_users_by_key(a, b, TurtleRP.sortByKey, TurtleRP.sortByOrder) end)
-    end
   end
 
   local currentFrameNumber = 1

--- a/scripts/TurtleRPDirectory.lua
+++ b/scripts/TurtleRPDirectory.lua
@@ -145,7 +145,55 @@ function TurtleRP.Directory_ScrollBar_Update()
 end
 
 function TurtleRP.renderDirectory(directoryOffset)
+<<<<<<< HEAD
   local searchResults = TurtleRP.DirectorySearchResults
+=======
+  local remadeArray = {}
+  local currentArrayNumber = 1
+  -- If NSFW is enabled, surface NSFW Status Column
+  if TurtleRPSettings["show_nsfw"] == "1" then
+    getglobal('NSFW_Column'):Show()
+  else
+    getglobal('NSFW_Column'):Hide()
+  end
+  for i, v in TurtleRPCharacters do
+    if TurtleRPCharacters[i] then
+      if not TurtleRPCharacters[i]['nsfw'] or TurtleRPCharacters[i]['nsfw'] == '' or TurtleRPCharacters[i]['nsfw'] == '0' or (TurtleRPCharacters[i]['nsfw'] == "1" and TurtleRPSettings["show_nsfw"] == "1") then
+         if TurtleRPCharacters[i]['full_name'] == nil then
+         TurtleRPCharacters[i]['full_name'] = ""
+         end
+         local resultShown = true
+         if TurtleRP.searchTerm ~= "" then
+         if string.find(string.lower(i), string.lower(TurtleRP.searchTerm)) == nil and string.find(string.lower(v['full_name']), string.lower(TurtleRP.searchTerm)) == nil then
+            resultShown = false
+         end
+         end
+         if resultShown then
+         remadeArray[currentArrayNumber] = v
+         remadeArray[currentArrayNumber]['player_name'] = i
+         remadeArray[currentArrayNumber]['status'] = "Offline"
+         remadeArray[currentArrayNumber]['zone'] = v['zone'] and v['zone'] or ""
+         if TurtleRPQueryablePlayers[i] then
+            if type(TurtleRPQueryablePlayers[i]) == "number" then
+               if TurtleRPQueryablePlayers[i] > (time() - 65) then
+               remadeArray[currentArrayNumber]['status'] = "Online"
+               end
+            end
+         end
+         currentArrayNumber = currentArrayNumber + 1
+         end
+      end
+    end
+  end
+
+  if TurtleRP.sortByKey ~= nil then
+    if TurtleRP.sortByOrder == 1 then
+      table.sort(remadeArray, function(a, b) return a[TurtleRP.sortByKey] > b[TurtleRP.sortByKey] end)
+    else
+      table.sort(remadeArray, function(a, b) return a[TurtleRP.sortByKey] < b[TurtleRP.sortByKey] end)
+    end
+  end
+>>>>>>> b0e0f82 (Add NSFW Column to Directory for players who have the Show NSFW flag enabled)
 
   local currentFrameNumber = 1
   if directoryOffset == 0 then
@@ -161,6 +209,16 @@ function TurtleRP.renderDirectory(directoryOffset)
       getglobal(thisFrameName .. 'Variable'):SetText(TurtleRP.secondColumn == "Character Name" and thisCharacter['full_name'] or thisCharacter['zone'])
       getglobal(thisFrameName .. '_StatusOffline'):Show()
       getglobal(thisFrameName .. '_StatusOnline'):Hide()
+      -- Only surface NSFW Column if show_nsfw is enabled
+      if TurtleRPSettings["show_nsfw"] == "1" then
+        getglobal(thisFrameName .. '_NSFWStatusFalse'):Show()
+        getglobal(thisFrameName .. '_NSFWStatusTrue'):Hide()
+      end
+      -- Update nsfw status if show_nsfw is enabled
+      if thisCharacter['nsfw'] == "1" and TurtleRPSettings["show_nsfw"] == "1" then
+        getglobal(thisFrameName .. '_NSFWStatusFalse'):Hide()
+        getglobal(thisFrameName .. '_NSFWStatusTrue'):Show()
+      end
       if thisCharacter['status'] == "Online" then
         getglobal(thisFrameName .. '_StatusOffline'):Hide()
         getglobal(thisFrameName .. '_StatusOnline'):Show()

--- a/scripts/TurtleRPDirectory.lua
+++ b/scripts/TurtleRPDirectory.lua
@@ -34,6 +34,45 @@ function TurtleRP.display_nearby_players()
   end)
 end
 
+-- Quick Helper Function to determine if user has key and then performs evaluation
+function sort_users_by_key(user1, user2, sort_key, sort_by_order)
+  -- if User 1 has a key proceed
+    if not (user1[sort_key] == nil) then
+      -- If User 2 also has a key proceed
+      if not (user2[sort_key] == nil) then
+        -- If sort is descending, do greater than
+        if sort_by_order == 1 then
+          return user1[sort_key] > user2[sort_key]
+        else
+          -- Less than if sort is ascending
+          return user1[sort_key] < user2[sort_key]
+        end
+      else
+        -- If user 2 does not have a key but user 1 does return true if descending
+        if sort_by_order == 1 then
+          return true
+        else
+        -- return false if not
+          return false
+        end
+      end
+    else
+      -- If user 1 doesn't have a key but user 2 does have a key
+      if not (user2[sort_key] == nil) then
+        -- return false if descending
+        if sort_by_order == 1 then
+          return false
+        else
+          -- and return true if ascending
+          return true
+        end
+      -- Final Catch if neither has a key, just return false
+      else
+        return false
+      end
+    end
+  end
+
 function TurtleRP.show_player_locations()
   local onlinePlayers = TurtleRP.get_players_online()
   local createdFrames = 0
@@ -188,9 +227,9 @@ function TurtleRP.renderDirectory(directoryOffset)
 
   if TurtleRP.sortByKey ~= nil then
     if TurtleRP.sortByOrder == 1 then
-      table.sort(remadeArray, function(a, b) return a[TurtleRP.sortByKey] > b[TurtleRP.sortByKey] end)
+      table.sort(remadeArray, function(a, b) return sort_users_by_key(a, b, TurtleRP.sortByKey, TurtleRP.sortByOrder) end)
     else
-      table.sort(remadeArray, function(a, b) return a[TurtleRP.sortByKey] < b[TurtleRP.sortByKey] end)
+      table.sort(remadeArray, function(a, b) return sort_users_by_key(a, b, TurtleRP.sortByKey, TurtleRP.sortByOrder) end)
     end
   end
 >>>>>>> b0e0f82 (Add NSFW Column to Directory for players who have the Show NSFW flag enabled)

--- a/scripts/TurtleRPDirectory.lua
+++ b/scripts/TurtleRPDirectory.lua
@@ -166,11 +166,7 @@ function TurtleRP.updateDirectorySearch()
     end
 
     if TurtleRP.sortByKey ~= nil then
-        if TurtleRP.sortByOrder == 1 then
-            table.sort(searchResults, function(a, b) return a[TurtleRP.sortByKey] > b[TurtleRP.sortByKey] end)
-        else
-            table.sort(searchResults, function(a, b) return a[TurtleRP.sortByKey] < b[TurtleRP.sortByKey] end)
-        end
+      table.sort(searchResults, function(a, b) return sort_users_by_key(a, b, TurtleRP.sortByKey, TurtleRP.sortByOrder) end)
     end
     TurtleRP.DirectorySearchResults = searchResults
 

--- a/scripts/TurtleRPDirectory.lua
+++ b/scripts/TurtleRPDirectory.lua
@@ -184,9 +184,7 @@ function TurtleRP.Directory_ScrollBar_Update()
 end
 
 function TurtleRP.renderDirectory(directoryOffset)
-<<<<<<< HEAD
   local searchResults = TurtleRP.DirectorySearchResults
-=======
   local remadeArray = {}
   local currentArrayNumber = 1
   -- If NSFW is enabled, surface NSFW Status Column
@@ -232,7 +230,6 @@ function TurtleRP.renderDirectory(directoryOffset)
       table.sort(remadeArray, function(a, b) return sort_users_by_key(a, b, TurtleRP.sortByKey, TurtleRP.sortByOrder) end)
     end
   end
->>>>>>> b0e0f82 (Add NSFW Column to Directory for players who have the Show NSFW flag enabled)
 
   local currentFrameNumber = 1
   if directoryOffset == 0 then


### PR DESCRIPTION
Hello!  While looking at the new patch I thought it might be useful to have the ability to specifically filter for NSFW profiles in the directory somewhere so its slightly more visible / you know what to expect when you click a profile in the directory if you have the 'show_nsfw' flag enabled,

This PR adds that small feature, creating a column to the Directory that only surfaces if you have the 'show_nsfw' flag enabled. Players who have checked the 'nsfw' button will have a green status box next to them. Also lets you sort for NSFW enabled profiles. 

Also reworked the sort filter to use a function that checks for nil values as it applies filter logic, as players who don't have the flag would throw an error. Almost assuredly a better way to do that but its functional. 

Hope you find the feature helpful, and if not feel free to close it! Thank you for your time and your continued work on this add-on! 